### PR TITLE
fix(shared): remove unneeded defensive code

### DIFF
--- a/src/shared/store.js
+++ b/src/shared/store.js
@@ -92,10 +92,7 @@ export const pullRequests = writable([]);
 const getSettingsByKey = (key, initial, type = undefined) => {
   let value = getItem(key);
 
-  if (
-    (typeof value !== 'boolean' && !value && value !== 0) ||
-    (value === undefined && value === null)
-  ) {
+  if (typeof value !== 'boolean' && !value && value !== 0) {
     value = initial;
     addItem(key, value);
 


### PR DESCRIPTION
Remove condition that always evaluates to false. `value` can't be null & undefined at the same time