### PR TITLE
fix(List): Manual refresh on empty list

### DIFF
--- a/src/components/MainView/MainView.scss
+++ b/src/components/MainView/MainView.scss
@@ -69,6 +69,22 @@
   }
 }
 
+.skz-refresh-button {
+  border: 0;
+  font-size: 1rem;
+  background-color: transparent;
+  text-decoration: underline;
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: none;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    color: #fff;
+  }
+}
+
 @media (prefers-color-scheme: dark) {
   .skz-fetching-status {
     color: #aaa;

--- a/src/components/MainView/MainView.svelte
+++ b/src/components/MainView/MainView.svelte
@@ -102,6 +102,8 @@
     }
   }
 
+  const manualRefresh = () => getPullRequests({ isFiltered: $listIsFiltered, organizations: $organizations, shouldNotify: true, profileId: $profile.id })
+
   $: tags = getAllTags($pullRequests);
   $: numberOfCheckedOrganizations = $organizations.filter(({ checked }) => checked).length;
   $: searchablePullRequests = selected.length > 0 ? $pullRequests.filter(x => x.labels && x.labels.filter(y => y.active && selected.includes(y.name.toLowerCase())).length > 0) : $pullRequests;
@@ -132,7 +134,12 @@
         <Pullrequest pullRequest={pullRequest}/>
       {:else}
         <li>
-          <p class="skz-pullrequests-list__empty">Il n'y a aucune pull request dans vos projets pour le moment.</p>
+          <p class="skz-pullrequests-list__empty">
+            Il n'y a aucune pull request dans vos projets pour le moment.
+            {#if !$isOffline && !$refreshDelay && !$isFetchingPullRequests}
+              <button class="skz-refresh-button" on:click={manualRefresh}>Rafraîchir</button>
+            {/if}
+          </p>
         </li>
       {/each}
     </ul>


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [ ] I have run `<TEST COMMAND>` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

I added a refresh button in empty list message. It appears only on manual refresh mode.
